### PR TITLE
Fix strict comparison issue

### DIFF
--- a/Model/Config/Backend/Order/Frequency.php
+++ b/Model/Config/Backend/Order/Frequency.php
@@ -111,7 +111,7 @@ class Frequency extends Value
     public function afterSave()
     {
         $time      = $this->getData('groups/schedule/fields/time/value');
-        $frequency = $this->getData('groups/schedule/fields/schedule_for/value');
+        $frequency = (int) $this->getData('groups/schedule/fields/schedule_for/value');
 
         if ($frequency !== ValueConfig::DISABLE) {
             $cronExprArray = [


### PR DESCRIPTION
It is potentially possible that the outcome of `$frequency` is a string. In our case, the outcome is `"0"` which then causes the code to process line 117 which leads to different issues.

I would prefer to make sure the outcome of `$frequency` is an int as its supposed to be.